### PR TITLE
Allow specifying time and delay in seconds, minutes or hours.

### DIFF
--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -7,29 +7,38 @@
   <string name="pref_category_about">Om</string>
   <string name="pref_category_other">Andre innstillinger</string>
   <string name="pref_category_time">Spilletid</string>
-  <string name="pref_dialog_title_delay_length">Angi tid (sekunder)</string>
+  <string name="pref_dialog_title_enter_time">Angi tid</string>
   <string name="pref_dialog_title_delay_type">Velg tilleggstid</string>
-  <string name="pref_dialog_title_starting_time">Angi tid (minutter)</string>
+  <string name="pref_dialog_title_time_units">Velg tidsenhet</string>
   <string name="pref_summary_alert_ringtone">Velg en ringetone som spilles av når tiden er ute.</string>
   <string name="pref_summary_delay_length">Velg hvor mye tid tillegg skal være på.</string>
   <string name="pref_summary_delay_type">Velg hvilken type tilleggstid som skal brukes i spillet.</string>
+  <string name="pref_summary_delay_length_units">Velg tidsenheten som tilleggstiden angis i.</string>
   <string name="pref_summary_haptic_feedback">Vibrer ved knappetrykk.</string>
   <string name="pref_summary_black_background">Sparer strøm på OLED-skjermer.</string>
   <string name="pref_summary_starting_time">Velg hvor mye tid hver spiller starter med.</string>
   <string name="pref_summary_starting_time_2">Velg hvor mye tid spiller 2 starter med.</string>
+  <string name="pref_summary_starting_time_units">Velg tidsenheten som spilletiden angis i.</string>
   <string name="pref_summary_different_starting_time">Bruk ulik spilltid per spiller.</string>
   <string name="pref_title_about">Om Simple Chess Clock</string>
   <string name="pref_title_alert_ringtone">Varseltone</string>
   <string name="pref_title_delay_length">Mengde tilleggstid</string>
   <string name="pref_title_delay_type">Type tilleggstid</string>
+  <string name="pref_title_delay_length_units">Tidsenhet for tilleggstid</string>
   <string name="pref_title_haptic_feedback">Vibrasjon</string>
   <string name="pref_title_black_background">Sort bakgrunn</string>
   <string name="pref_title_starting_time">Spilletid</string>
   <string name="pref_title_starting_time_2">Spilletid (spiller 2)</string>
+  <string name="pref_title_starting_time_units">Tidsenhet for spilletid</string>
   <string name="pref_title_different_starting_time">Ulik spilletid</string>
   <string-array name="delay_types">
     <item>Ingen</item>
     <item>Fischer</item>
     <item>Bronstein</item>
+  </string-array>
+  <string-array name="time_units">
+      <item>Sekunder</item>
+      <item>Minutter</item>
+      <item>Timer</item>
   </string-array>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -8,25 +8,29 @@
   <string name="pref_category_about">About</string>
   <string name="pref_category_other">Other Options</string>
   <string name="pref_category_time">Game Time</string>
-  <string name="pref_dialog_title_delay_length">Enter Time (seconds)</string>
+  <string name="pref_dialog_title_enter_time">Enter Time</string>
   <string name="pref_dialog_title_delay_type">Select Time Delay</string>
-  <string name="pref_dialog_title_starting_time">Enter Time (minutes)</string>
+  <string name="pref_dialog_title_time_units">Select Time Units</string>
   <string name="pref_summary_alert_ringtone">Set the ringtone to be played when time expires.</string>
   <string name="pref_summary_delay_length">Set the amount of time used for time delays.</string>
   <string name="pref_summary_delay_type">Set the time delay scheme to use during play.</string>
+  <string name="pref_summary_delay_length_units">Set units in which to specify delay length.</string>
   <string name="pref_summary_haptic_feedback">Vibrate slightly on button presses.</string>
   <string name="pref_summary_black_background">Saves power on OLED screens.</string>
   <string name="pref_summary_starting_time">Set how much time each player starts with.</string>
   <string name="pref_summary_starting_time_2">Set how much time Player 2 starts with.</string>
+  <string name="pref_summary_starting_time_units">Set units in which to specify game time.</string>
   <string name="pref_summary_different_starting_time">Use a different game time for each player.</string>
   <string name="pref_title_about">About Simple Chess Clock</string>
   <string name="pref_title_alert_ringtone">Alert Ringtone</string>
   <string name="pref_title_delay_length">Delay Length</string>
   <string name="pref_title_delay_type">Delay Type</string>
+  <string name="pref_title_delay_length_units">Delay Length Units</string>
   <string name="pref_title_haptic_feedback">Haptic Feedback</string>
   <string name="pref_title_black_background">Black Background</string>
   <string name="pref_title_starting_time">Game Time</string>
   <string name="pref_title_starting_time_2">Game Time (Player 2)</string>
+  <string name="pref_title_starting_time_units">Game Time Units</string>
   <string name="pref_title_different_starting_time">Different Game Time</string>
   <string-array name="delay_types">
     <item>None</item>
@@ -37,5 +41,15 @@
     <item>None</item>
     <item>Fischer</item>
     <item>Bronstein</item>
+  </string-array>
+  <string-array name="time_units">
+      <item>Seconds</item>
+      <item>Minutes</item>
+      <item>Hours</item>
+  </string-array>
+  <string-array name="time_unit_vals" translatable="false">
+      <item>Seconds</item>
+      <item>Minutes</item>
+      <item>Hours</item>
   </string-array>
 </resources>

--- a/res/xml-port/preferences.xml
+++ b/res/xml-port/preferences.xml
@@ -3,9 +3,20 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
   <PreferenceCategory
       android:title="@string/pref_category_time">
+    <ListPreference
+        android:entries="@array/time_units"
+        android:dialogTitle="@string/pref_dialog_title_time_units"
+        android:entryValues="@array/time_unit_vals"
+        android:selectable="true"
+        android:summary="@string/pref_summary_starting_time_units"
+        android:enabled="true"
+        android:title="@string/pref_title_starting_time_units"
+        android:key="prefInitTimeUnits"
+        android:defaultValue="Minutes">
+    </ListPreference>
     <EditTextPreference
         android:inputType="number"
-        android:dialogTitle="@string/pref_dialog_title_starting_time"
+        android:dialogTitle="@string/pref_dialog_title_enter_time"
         android:title="@string/pref_title_starting_time"
         android:summary="@string/pref_summary_starting_time"
         android:defaultValue="10"
@@ -23,7 +34,7 @@
     </CheckBoxPreference>
     <EditTextPreference
         android:inputType="number"
-        android:dialogTitle="@string/pref_dialog_title_starting_time"
+        android:dialogTitle="@string/pref_dialog_title_enter_time"
         android:title="@string/pref_title_starting_time_2"
         android:summary="@string/pref_summary_starting_time_2"
         android:defaultValue="10"
@@ -43,6 +54,17 @@
         android:key="prefDelay"
         android:defaultValue="None">
     </ListPreference>
+    <ListPreference
+        android:entries="@array/time_units"
+        android:dialogTitle="@string/pref_dialog_title_time_units"
+        android:entryValues="@array/time_unit_vals"
+        android:selectable="true"
+        android:summary="@string/pref_summary_delay_length_units"
+        android:enabled="true"
+        android:title="@string/pref_title_delay_length_units"
+        android:key="prefDelayTimeUnits"
+        android:defaultValue="Seconds">
+    </ListPreference>
     <EditTextPreference
         android:inputType="number"
         android:key="prefDelayTime"
@@ -51,7 +73,7 @@
         android:enabled="true"
         android:defaultValue="0"
         android:selectable="true"
-        android:dialogTitle="@string/pref_dialog_title_delay_length">
+        android:dialogTitle="@string/pref_dialog_title_enter_time">
     </EditTextPreference>
   </PreferenceCategory>
   <PreferenceCategory


### PR DESCRIPTION
This PR adds two new preferences, Game Time Units and Delay Length Units. 
Each allow the user to select the units (seconds, minutes, or hours) in which to specify Game Time and Delay Length, with defaults of minutes and seconds respectively. The app logic is updated to reflect these settings.

Why is this useful? Currently there is no way for users to specify time controls under one minute. While they might be rare, over-the-board hyper-bullet aficionados do exist. This change also makes specifying longer increments,  i.e. 10 minutes, or longer game times, i.e 4 hours, a little bit nicer. 

Norwegian translations were done with zero knowledge of Norwegian and heavy use of Google Translate, please accept my apologies in advance.