### PR TITLE
Refactor time display to include hours and deciseconds

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -17,6 +17,7 @@
   <string name="pref_summary_delay_length_units">Set units in which to specify delay length.</string>
   <string name="pref_summary_haptic_feedback">Vibrate slightly on button presses.</string>
   <string name="pref_summary_black_background">Saves power on OLED screens.</string>
+  <string name="pref_summary_show_deciseconds">Display tenths of seconds when clock or delay is below 10 seconds.</string>
   <string name="pref_summary_starting_time">Set how much time each player starts with.</string>
   <string name="pref_summary_starting_time_2">Set how much time Player 2 starts with.</string>
   <string name="pref_summary_starting_time_units">Set units in which to specify game time.</string>
@@ -28,6 +29,7 @@
   <string name="pref_title_delay_length_units">Delay Length Units</string>
   <string name="pref_title_haptic_feedback">Haptic Feedback</string>
   <string name="pref_title_black_background">Black Background</string>
+  <string name="pref_title_show_deciseconds">Display Deciseconds</string>
   <string name="pref_title_starting_time">Game Time</string>
   <string name="pref_title_starting_time_2">Game Time (Player 2)</string>
   <string name="pref_title_starting_time_units">Game Time Units</string>

--- a/res/xml-port/preferences.xml
+++ b/res/xml-port/preferences.xml
@@ -75,6 +75,14 @@
         android:selectable="true"
         android:dialogTitle="@string/pref_dialog_title_enter_time">
     </EditTextPreference>
+    <CheckBoxPreference
+        android:title="@string/pref_title_show_deciseconds"
+        android:enabled="true"
+        android:selectable="true"
+        android:defaultValue="true"
+        android:summary="@string/pref_summary_show_deciseconds"
+        android:key="prefShowDeciseconds">
+    </CheckBoxPreference>
   </PreferenceCategory>
   <PreferenceCategory
       android:title="@string/pref_category_other">


### PR DESCRIPTION
Follow-up to https://github.com/simenheg/simple-chess-clock/pull/10, this PR refactors `formatTime` to display hours if time remaining is long enough, and deciseconds (tenths of a second) if time remaining is short enough. I hope to have streamlined some of the relevant logic along the way. 

Why is this useful? With low amounts of time remaining on the clock, fractions of a second might make a difference (you can make a move in 0.9s, but probably not in 0.1s). Time durations above an hour are also now more readable. Bronstein increments are displayed on a separate line to avoid line breaks at awkward points.